### PR TITLE
git 忽略规则更改，打开source/_post/文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 _deploy
 public
 sass
-source/_*
+source/_includes
+source/_layouts
 source/stylesheets/screen.css
 vendor
 node_modules


### PR DESCRIPTION
原来source/_post文件夹在git中被忽略掉了，导致新建的文件无法git
